### PR TITLE
Fixed bug :  Dynamic Block Inserter dissapearing #54

### DIFF
--- a/awt-admin/javascript/pageEditor/blockInsertion.js
+++ b/awt-admin/javascript/pageEditor/blockInsertion.js
@@ -17,8 +17,8 @@ function insertBlock() {
         event.stopPropagation();
         $currentElement = $(event.currentTarget);
         if ($currentElement.hasClass("replacable")) return;
-        if ($currentElement.attr('id') == "grid-block") return;
-        if ($currentElement.parent().attr('id') == "grid-block") return;
+        // if ($currentElement.attr('id') == "grid-block") return;
+        // if ($currentElement.parent().attr('id') == "grid-block") return;
         if (floatingBlockSelectorActive) return;
 
         if (movingBlocks) {


### PR DESCRIPTION
This seems to fix the bug, however.  The inserter seems to be broken when not in the active tab.

Needs further testing.